### PR TITLE
Add DB setup to scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # gogen
-go generate rest api cli
+
+CLI tool to generate Go REST API projects using Gin.
+
+Features:
+- Automatically sets up Swagger documentation.
+- Configures a MariaDB database using Gorm.
+
+## Usage
+
+```bash
+gogen create myapp
+```
+
+The generated project will include Swagger and database setup. Provide the MariaDB connection string via the `DB_DSN` environment variable. If not set, a default DSN connecting to `localhost:3306` will be used.
+


### PR DESCRIPTION
## Summary
- scaffold gorm DB setup in generated projects
- use MariaDB instead of SQLite
- document DB feature in README

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ea9169644832a8201540b970357af