### PR TITLE
Enable HTTPS support in generated app

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ CLI tool to generate Go REST API projects using Gin.
 Features:
 - Automatically sets up Swagger documentation.
 - Configures a MariaDB database using Gorm.
+- Supports HTTPS when `SSL_CERT_FILE` and `SSL_KEY_FILE` are provided.
 
 ## Usage
 
@@ -13,4 +14,6 @@ gogen create myapp
 ```
 
 The generated project will include Swagger and database setup. Provide the MariaDB connection string via the `DB_DSN` environment variable. If not set, a default DSN connecting to `localhost:3306` will be used.
+
+To enable HTTPS during development, set `SSL_CERT_FILE` and `SSL_KEY_FILE` to the paths of your certificate and private key.
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -138,6 +138,7 @@ import (
         "github.com/gin-gonic/gin"
         "github.com/swaggo/files"
         "github.com/swaggo/gin-swagger"
+        "os"
         "{{.}}/internal/common"
         "{{.}}/internal/domain"
         "{{.}}/internal/handler"
@@ -164,9 +165,15 @@ func main() {
 	r.PUT("/users/:id", handler.UpdateUser)
 	r.DELETE("/users/:id", handler.DeleteUser)
 
-	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+        r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	r.Run(":8080")
+        cert := os.Getenv("SSL_CERT_FILE")
+        key := os.Getenv("SSL_KEY_FILE")
+        if cert != "" && key != "" {
+                r.RunTLS(":8080", cert, key)
+        } else {
+                r.Run(":8080")
+        }
 }
 `
 


### PR DESCRIPTION
## Summary
- support running generated server with TLS if SSL_CERT_FILE and SSL_KEY_FILE are set
- document new HTTPS environment variables in README

## Testing
- `go build ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684eb93d00bc832abbdbc3e28d65932c